### PR TITLE
[twitter] Fix stop before real end

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -231,7 +231,7 @@ class TwitterExtractor(Extractor):
                     data["items_html"], '<div class="tweet ', '\n</li>'):
                 yield tweet
 
-            if not data["has_more_items"]:
+            if not data["has_more_items"] and data["min_position"] == None:
                 return
 
             if "min_position" in data:


### PR DESCRIPTION
Fix for https://github.com/mikf/gallery-dl/issues/544. Makes sure that it really reached the end by checking that both "min_position" is null and "has_more_items" is false before stopping.